### PR TITLE
zed/dca/common/stdio_file.h: do not include malloc.h on macOS

### DIFF
--- a/qmmp/src/plugins/Input/zed/dca/common/stdio_file.h
+++ b/qmmp/src/plugins/Input/zed/dca/common/stdio_file.h
@@ -22,7 +22,9 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
+#ifndef __APPLE__
 #include <malloc.h>
+#endif
 
 #ifndef	MIN
 #define MIN(x, y) ((x) < (y) ? (x) : (y))


### PR DESCRIPTION
There is no such a header on macOS, there is `malloc/malloc.h`, but here including `stdlib.h` is sufficient.