### PR TITLE
zed plugin: include optimfrog only on x86

### DIFF
--- a/qmmp/src/plugins/Input/zed/zed.pro
+++ b/qmmp/src/plugins/Input/zed/zed.pro
@@ -1,11 +1,10 @@
-TEMPLATE = subdirs     
+TEMPLATE = subdirs
 
 SUBDIRS += adplug
 SUBDIRS += archive
 SUBDIRS += buzzic
 SUBDIRS += dca
 SUBDIRS += ken
-SUBDIRS += optimfrog
 SUBDIRS += organya
 SUBDIRS += psf
 SUBDIRS += qoa
@@ -14,3 +13,7 @@ SUBDIRS += sunvox
 SUBDIRS += v2m
 SUBDIRS += xmdx
 SUBDIRS += xsf
+
+contains(QT_ARCH, "i386")|contains(QT_ARCH, "x86_64") {
+    SUBDIRS += optimfrog
+}


### PR DESCRIPTION
Closes: https://github.com/cspiegel/qmmp-optimfrog/issues/1

@Greedysky This should work, right?