### PR TITLE
ttkdesktopscreen.cpp: fix typo in Qt4 code chunk

### DIFF
--- a/TTKCommon/TTKLibrary/ttkdesktopscreen.cpp
+++ b/TTKCommon/TTKLibrary/ttkdesktopscreen.cpp
@@ -217,8 +217,8 @@ static QSize generateDPIValue()
     QDesktopWidget* desktop = QApplication::desktop();
     if(desktop)
     {
-        dpiSize.setWidth(screen->logicalDpiX());
-        dpiSize.setHeight(screen->logicalDpiY());
+        dpiSize.setWidth(desktop->logicalDpiX());
+        dpiSize.setHeight(desktop->logicalDpiY());
     }
 #endif
 #endif


### PR DESCRIPTION
@Greedysky Should be `desktop` here, I guess.