### PR TITLE
Minor fixes to TTKThirdParty

### DIFF
--- a/TTKThirdParty/TTKExtras/CMakeLists.txt
+++ b/TTKThirdParty/TTKExtras/CMakeLists.txt
@@ -223,6 +223,14 @@ endif()
 
 set(QT_LINK_LIBS TTKLibrary TTKUi)
 
+# qglobalshortcut_mac.cpp needs this.
+# Notice, it cannot work on recent macOS versions,
+# so either additional implementation is needed, using
+# modern API, or at least a dummy fallback.
+if(APPLE)
+  list(APPEND QT_LINK_LIBS "-framework Carbon")
+endif()
+
 if(TTK_QT_VERSION VERSION_EQUAL "4")
   qt4_wrap_cpp(MOC_FILES ${HEADER_FILES})
 

--- a/TTKThirdParty/Zlib/zlib/gzguts.h
+++ b/TTKThirdParty/Zlib/zlib/gzguts.h
@@ -34,6 +34,10 @@
 #  include <stddef.h>
 #endif
 
+#ifdef __APPLE__
+#include <unistd.h> /* close, read, write etc. */
+#endif
+
 #if defined(__TURBOC__) || defined(_MSC_VER) || defined(_WIN32)
 #  include <io.h>
 #endif


### PR DESCRIPTION
@Greedysky I have added earlier `-undefined dynamic_lookup` when I needed a quick build on arm64 and forgot to drop it. Once dropped, it revealed two issues: with undefined symbols in zlib and missing framework linking. Here are the fixes.