### PR TITLE
Add missing <cmath> headers to fix build

### DIFF
--- a/qmmp/src/plugins/Effect/bitcrusher/bitcrusherplugin.cpp
+++ b/qmmp/src/plugins/Effect/bitcrusher/bitcrusherplugin.cpp
@@ -3,6 +3,8 @@
 #include <QSettings>
 #include <qmath.h>
 
+#include <cmath>
+
 BitcrusherPlugin *BitcrusherPlugin::m_instance = nullptr;
 
 BitcrusherPlugin::BitcrusherPlugin()

--- a/qmmp/src/plugins/Effect/silence/silenceplugin.cpp
+++ b/qmmp/src/plugins/Effect/silence/silenceplugin.cpp
@@ -3,6 +3,8 @@
 #include <QSettings>
 #include <qmath.h>
 
+#include <cmath>
+
 static float* alignFrame(int channels, float* begin, float* sample, bool end)
 {
     if(!sample)

--- a/qmmp/src/plugins/Light/lightwaveform/lightwaveform.cpp
+++ b/qmmp/src/plugins/Light/lightwaveform/lightwaveform.cpp
@@ -6,7 +6,7 @@
 #include <QSettings>
 #include <QMouseEvent>
 
-#include <math.h>
+#include <cmath>
 #include <qmmp/buffer.h>
 #include <qmmp/decoder.h>
 #include <qmmp/soundcore.h>


### PR DESCRIPTION
@Greedysky  To fix build errors with the current tree:
```
:info:build make[3]: Entering directory `/opt/local/var/macports/build/libqmmp-5f1cd230/work/TTKMusicPlayer-f35e3c16c42f73dad3fe33e1b43e81e01f1e5046/qmmp/src/plugins/Output/pulseaudio'
:info:build /opt/local/var/macports/build/libqmmp-5f1cd230/work/compwrap/cxx/usr/bin/clang++ -c -I/opt/local/include -Os -stdlib=libc++ -arch x86_64 -std=c++11 -O2 -arch x86_64 -Xarch_x86_64 -mmacosx-version-min=10.15 -w -fvisibility=hidden -fvisibility-inlines-hidden -fPIC -DQT_NO_CAST_FROM_BYTEARRAY -DQT_STRICT_ITERATORS -DQMMP_LIBRARY -DQT_NO_DEBUG -DQT_PLUGIN -DQT_GUI_LIB -DQT_CORE_LIB -DQT_SHARED -I/opt/local/libexec/qt4/share/mkspecs/macx-g++ -I. -I.build/moc -I/opt/local/libexec/qt4/Library/Frameworks/QtCore.framework/Versions/4/Headers -I/opt/local/libexec/qt4/Library/Frameworks/QtGui.framework/Versions/4/Headers -I../../../../src -I/opt/local/libexec/qt4/Library/Frameworks/QtGui.framework/Versions/4/Headers -I/opt/local/libexec/qt4/Library/Frameworks/QtCore.framework/Versions/4/Headers -I/opt/local/libexec/qt4/include -F/opt/local/libexec/qt4/Library/Frameworks -F/opt/local/libexec/qt4/lib -o .build/obj/outputpulseaudiofactory.o outputpulseaudiofactory.cpp
:info:build lightwaveform.cpp:307:40: error: no member named 'sqrt' in namespace 'std'
:info:build                         m_data << std::sqrt(vrms[ch] / frame_counter) * 1000;
:info:build                                   ~~~~~^
:info:build 1 error generated.
:info:build make[3]: *** [.build/obj/lightwaveform.o] Error 1
:info:build make[3]: Leaving directory `/opt/local/var/macports/build/libqmmp-5f1cd230/work/TTKMusicPlayer-f35e3c16c42f73dad3fe33e1b43e81e01f1e5046/qmmp/src/plugins/Light/lightwaveform'
:info:build make[2]: *** [sub-lightwaveform-all] Error 2
:info:build make[2]: Leaving directory `/opt/local/var/macports/build/libqmmp-5f1cd230/work/TTKMusicPlayer-f35e3c16c42f73dad3fe33e1b43e81e01f1e5046/qmmp/src/plugins/Light'
:info:build make[1]: *** [sub-Light-all] Error 2
:info:build make[1]: cd buzzic/ && /Library/Developer/CommandLineTools/usr/bin/make -f Makefile all
:info:build *** Waiting for unfinished jobs....

:info:build bitcrusherplugin.cpp:26:26: error: no member named 'pow' in namespace 'std'; did you mean simply 'pow'?
:info:build     const double scale = std::pow(2.0, m_depth) / 2.;
:info:build                          ^~~~~~~~
:info:build                          pow
:info:build /Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/math.h:1039:1: note: 'pow' declared here
:info:build pow(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
:info:build ^
:info:build /Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/math.h:1042:5: error: static_assert failed due to requirement '!(std::integral_constant<bool, true>::value && std::integral_constant<bool, true>::value)' ""
:info:build     static_assert((!(std::_IsSame<_A1, __result_type>::value &&
:info:build     ^              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
:info:build bitcrusherplugin.cpp:26:31: note: in instantiation of function template specialization 'pow<double, double>' requested here
:info:build     const double scale = std::pow(2.0, m_depth) / 2.;
:info:build                               ^
:info:build 2 errors generated.

:info:build silenceplugin.cpp:39:29: error: no member named 'pow' in namespace 'std'; did you mean simply 'pow'?
:info:build     const float threshold = std::pow(10, m_threshold / 20.0f);
:info:build                             ^~~~~~~~
:info:build                             pow
:info:build /Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/math.h:1039:1: note: 'pow' declared here
:info:build pow(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
:info:build ^
:info:build 1 error generated.
:info:build make[3]: *** [.build/obj/silenceplugin.o] Error 1
:info:build make[3]: *** Waiting for unfinished jobs....
```
